### PR TITLE
fix: Teams notify workflow broken by apostrophe in label JSON

### DIFF
--- a/.github/workflows/teams-notify.yml
+++ b/.github/workflows/teams-notify.yml
@@ -9,35 +9,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Teams notification
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_LABELS: ${{ toJson(github.event.issue.labels) }}
+          TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
         run: |
-          # Extract first label or default to "Issue"
-          LABEL=$(echo '${{ toJson(github.event.issue.labels) }}' | jq -r '.[0].name // "Issue"')
+          LABEL=$(echo "$ISSUE_LABELS" | jq -r '.[0].name // "Issue"')
 
-          curl -H "Content-Type: application/json" -d '{
-            "@type": "MessageCard",
-            "@context": "http://schema.org/extensions",
-            "themeColor": "0076D7",
-            "summary": "New issue in ds01-hub",
-            "sections": [{
-              "activityTitle": "[${{ github.event.issue.title }}](${{ github.event.issue.html_url }})",
-              "facts": [{
-                "name": "Type",
-                "value": "'"${LABEL}"'"
-              }, {
-                "name": "Opened by",
-                "value": "${{ github.event.issue.user.login }}"
+          PAYLOAD=$(jq -n \
+            --arg title "$ISSUE_TITLE" \
+            --arg url "$ISSUE_URL" \
+            --arg label "$LABEL" \
+            --arg author "$ISSUE_AUTHOR" \
+            '{
+              "@type": "MessageCard",
+              "@context": "http://schema.org/extensions",
+              "themeColor": "0076D7",
+              "summary": "New issue in ds01-hub",
+              "sections": [{
+                "activityTitle": "[\($title)](\($url))",
+                "facts": [
+                  {"name": "Type", "value": $label},
+                  {"name": "Opened by", "value": $author}
+                ],
+                "markdown": true
               }],
-              "markdown": true
-            }],
-            "potentialAction": [{
-              "@type": "OpenUri",
-              "name": "View Issue",
-              "targets": [{
-                "os": "default",
-                "uri": "${{ github.event.issue.html_url }}"
+              "potentialAction": [{
+                "@type": "OpenUri",
+                "name": "View Issue",
+                "targets": [{"os": "default", "uri": $url}]
               }]
-            }]
-          }' ${{ secrets.TEAMS_WEBHOOK_URL }}
+            }')
+
+          curl -sf -H "Content-Type: application/json" -d "$PAYLOAD" "$TEAMS_WEBHOOK_URL"
 
 # ============================================================
 # SETUP INSTRUCTIONS FOR TEAMS WEBHOOK


### PR DESCRIPTION
## Summary
- The `teams-notify.yml` workflow always failed because `toJson(github.event.issue.labels)` produces JSON containing `"Something isn't working"` (the default GitHub "bug" label description). The apostrophe breaks the single-quoted `echo '...'` shell command, causing a bash syntax error.
- Additionally, the issue title was interpolated directly into the `curl` JSON payload via `${{ }}`, which is vulnerable to shell injection if the title contains special characters.

## Fix
- Move all GitHub expressions (`${{ }}`) into `env:` variables, which are safely passed to the shell without interpolation issues.
- Build the JSON payload using `jq -n` with `--arg`, which properly escapes all string values (apostrophes, quotes, newlines, etc.).
- Add `-sf` flags to `curl` for silent progress + fail on HTTP errors.

## Test plan
- [ ] Open a test issue with the "bug" label (which has the apostrophe in its description) and verify the workflow succeeds
- [ ] Open a test issue with special characters in the title (e.g. quotes, backticks) and verify it succeeds
- [ ] Verify the Teams message card renders correctly with the issue link, label, and author