### PR TITLE
docs: two-path landing + strip residual emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The support hub for `ds01` - Hertie Data Science Lab's GPU server for containeri
 
 ## Documentation
 
-📖 **[hertie-data-science-lab.github.io/ds01](https://hertie-data-science-lab.github.io/ds01/)** — the
+**[hertie-data-science-lab.github.io/ds01](https://hertie-data-science-lab.github.io/ds01/)** — the
 searchable documentation site (getting started, core guides, intermediate &
 advanced workflows, key concepts, reference, and troubleshooting).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,13 @@
 # DS01 User Documentation
 
+**New here? Pick a path:**
+
+| [**Deploy in ~30 minutes →**](quickstart.md) | [**Explore the full guide →**](getting-started/) |
+|:---|:---|
+| Get straight to a running GPU container: connect via SSH, set up your keys, and deploy your first containerised project. | Work through the docs properly — setup, key concepts, daily workflow, then intermediate and advanced topics at your own pace. |
+
+---
+
 ## Documentation Structure
 
 ```
@@ -27,7 +35,7 @@ docs/
 ### Path 1: Beginner (Students, First-Time Users)
 **"I just want to work on my thesis"**
 
-> **⏱ In a hurry?** Try the [Quickstart](quickstart.md) for a condensed intro (~30 min).
+> **In a hurry?** Try the [Quickstart](quickstart.md) for a condensed intro (~30 min).
 
 **Essential (do these first):**
 1. [Prerequisites](getting-started/prerequisites.md) - Check what you need

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -71,7 +71,7 @@ const config: Config = {
       items: [
         {
           href: 'https://hertie-data-science-lab.github.io/ds01-infra/',
-          label: 'Full docs (admin/dev) ↗',
+          label: 'Full documentation',
           position: 'right',
         },
         {


### PR DESCRIPTION
Polish pass on the end-user site.

- **Two-path landing**: prominent side-by-side "choose your path" opening — *Deploy in ~30 minutes* (quickstart) vs *Explore the full guide* — so the 30-minute quickstart is visible immediately (synced from ds01-infra/docs-user).
- **Emoji removed**: dropped the book emoji from the README and the `↗` from the navbar label; synced the decorative-emoji cleanup into `docs/`.

Diagram arrows and `✓`/`✗` status glyphs are preserved.

## Test plan
- `cd website && npm ci && npm run build` — clean build, two-path block renders on the site root.